### PR TITLE
Changed eval to exec

### DIFF
--- a/awsc/sts/mfa_auth.go
+++ b/awsc/sts/mfa_auth.go
@@ -111,7 +111,7 @@ AWS_PROFILE='%s' awsc auth \
 
 . %s.env
 
-eval "$@"
+exec "$@"
 `,
 		profile,
 		cacheDir,


### PR DESCRIPTION
Changing `eval` to `exec` resolves conflicts with some commands that include colons and ampersands. 